### PR TITLE
adding send-keys

### DIFF
--- a/gotmux/pane.go
+++ b/gotmux/pane.go
@@ -85,6 +85,22 @@ const (
 	PaneSplitDirectionVertical   PaneSplitDirection = "-v"
 )
 
+// Pane send-keys.
+//
+// Reference: https://man.openbsd.org/OpenBSD-current/man1/tmux.1#send-keys
+func (p *Pane) SendKeys(line string) error {
+	_, err := p.tmux.query().
+		cmd("send-keys").
+		fargs("-t", p.Id).
+                pargs(line).
+		run()
+	if err != nil {
+		return errors.New("failed to send keys")
+	}
+
+	return nil
+}
+
 // Kills the pane.
 //
 // Reference: https://man.openbsd.org/OpenBSD-current/man1/tmux.1#kill-pane


### PR DESCRIPTION
Adding tmux send-keys - I've needed for my project

`
    pane, err := windows[0].GetPaneByIndex(0)
    if err != nil {
      fmt.Println("error get window")
      return
    }

    cap, err := pane.Capture()
    if err != nil {
        fmt.Println("error pane capture")
    }
    fmt.Println("cap")
    fmt.Println(cap)
    err = pane.SendKeys("find . \n")
    if err != nil {
       fmt.Println(err)
    }

    cap, err = pane.Capture()
    if err != nil {
        fmt.Println(err)
    }
    fmt.Println("cap")
    fmt.Println(cap)`